### PR TITLE
Use goreleaser to automatically build and publish binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: GoReleaser Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.x"
+        id: go
+
+      - name: run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,72 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+    - go test
+
+builds:
+  - id: go-curling
+    binary: go-curling
+    ldflags:
+      - -extldflags "-static" -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - freebsd
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - ppc64le
+    goarm:
+      - "7"
+    ignore:
+      - goos: freebsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: ppc64le
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: ppc64le
+
+  - id: go-curling-win
+    binary: go-curling
+    ldflags:
+      - -extldflags "-static" -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.xz
+    format_overrides:
+      - goos: windows
+        format: zip
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+      - SECURITY.md
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}--checksums.txt"
+release:
+  draft: false
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ curl https://google.com
 curl https://my.local.test:443 -k
 ```
 
+# Install
+
+## Binary Release
+
+You can manually download a binary release for Linux, MacOS, Windows or FreeBSD
+from the [releases](https://github.com/cdwiegand/go-curling/releases) page.
+
+## Go
+
+Please notice `latest` will install the dev version:
+
+```sh
+go install -ldflags="-s -w" -v github.com/cdwiegand/go-curling@latest
+```
+
 # Using in a Dockerfile
 ```
 COPY --from=cdwiegand/go-curling:latest /bin/curl /usr/bin/curl


### PR DESCRIPTION
This PR will automatically build and publish binaries to the `Releases` section of your GitHub repo.  To trigger a build after you finalize a new version you would still need to manually run something like:

```shell
$ git tag -a v1.1.0 -m 1.1.0
$ git push origin v1.1.0
```

I have personally tested the built binaries on MacOS (arm64), Linux (amd64, arm) and Windows (amd64).

Here is the build process in my forked repo: https://github.com/jftuga/go-curling/actions/runs/12529882163

Here is what your release and binaries would look like: https://github.com/jftuga/go-curling/releases
* scroll down to see the `Assets`

If this PR is accepted, I would then remove my forked repo, along with those releases & binaries to avoid any confusion.
